### PR TITLE
HTTPS and shorter env syntax

### DIFF
--- a/yql.go
+++ b/yql.go
@@ -37,7 +37,7 @@ func (d *YQLDriver) Open(dsn string) (driver.Conn, error) {
 
 	}
 	if dsn != "" {
-		return &YQLConn{c: http.DefaultClient, env: dsn}
+		return &YQLConn{c: http.DefaultClient, env: dsn}, nil
 	}
 	return &YQLConn{c: http.DefaultClient}, nil
 }

--- a/yql.go
+++ b/yql.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-const endpoint = "http://query.yahooapis.com/v1/public/yql"
+const endpoint = "https://query.yahooapis.com/v1/public/yql"
 
 var (
 	yqlOauth *oauth.OAuthConsumer
@@ -35,6 +35,9 @@ func (d *YQLDriver) Open(dsn string) (driver.Conn, error) {
 			return &YQLConn{http.DefaultClient, parts[0], parts[1], parts[2]}, nil
 		}
 
+	}
+	if dsn != "" {
+		return &YQLConn{c: http.DefaultClient, env: dsn}
 	}
 	return &YQLConn{c: http.DefaultClient}, nil
 }


### PR DESCRIPTION
Hello.

This PR allows to just specify the environment in the dsn without the two pipes before it, making it two characters shorter, but most importantly, a bit prettier.

This PR also makes the query be made over HTTPS.
